### PR TITLE
I've made some modifications to the `performGoogleSearch` function in…

### DIFF
--- a/netlify/functions/fetch-ufc.js
+++ b/netlify/functions/fetch-ufc.js
@@ -48,8 +48,18 @@ function performGoogleSearch(query) {
       res.on('end', () => {
         console.log(`[GoogleSearch] Response ended. Status: ${res.statusCode}, Length: ${data.length}`);
         if (res.statusCode === 200) {
+          // Log the beginning of the HTML content for debugging
+          console.log("--- START OF GOOGLE HTML LOG ---");
+          console.log(data.substring(0, 15000)); // Log the first 15000 characters
+          console.log("--- END OF GOOGLE HTML LOG ---");
           resolve(data);
         } else {
+          // Also log partial data on error if any was received
+          if (data && data.length > 0) {
+            console.log("--- START OF GOOGLE HTML LOG (ERROR RESPONSE) ---");
+            console.log(data.substring(0, 15000));
+            console.log("--- END OF GOOGLE HTML LOG (ERROR RESPONSE) ---");
+          }
           reject(new Error(`Google search failed with status: ${res.statusCode}`));
         }
       });


### PR DESCRIPTION
… `netlify/functions/fetch-ufc.js`. Now, it will log the first 15,000 characters of the HTML response from Google. This should help with debugging by allowing us to analyze the HTML structure and improve the scraping logic if any parsing issues arise.