### PR TITLE
Feat: Integrate Google Custom Search JSON API for UFC data

### DIFF
--- a/ufcFetcher.js
+++ b/ufcFetcher.js
@@ -1,1047 +1,273 @@
+require('dotenv').config(); // For local execution to load .env variables
 const https = require('https');
-const fs = require('fs');
-const path = require('path');
-const GoogleUFCScraper = require('./googleUFCScraper');
+// const GoogleUFCScraper = require('./googleUFCScraper'); // No longer needed
+// const { getOrdinalSuffix } = require('./utils'); // Might not be needed
 
 class UFCFetcher {
-  constructor() {
-    // Using multiple data sources for better accuracy
-    this.baseUrl = 'www.thesportsdb.com';
-    this.apiPath = '/api/v1/json/3';
-    
-    // Initialize Google scraper for accurate times
-    this.googleScraper = new GoogleUFCScraper();
-    
-    // Map TheSportsDB event statuses to our system
-    this.statusMap = {
-      'Not Started': 'upcoming',
-      'Match Finished': 'finished',
-      'Live': 'live',
-      'Postponed': 'postponed',
-      'Cancelled': 'cancelled'
-    };
-  }
-
-  /**
-   * Get accurate UK UFC broadcast channels based on event type
-   * @param {string} eventType - Type of UFC event
-   * @param {string} ufcNumber - UFC number (for PPV events)
-   * @returns {string} Accurate UK broadcast channel
-   */
-  getUKUFCBroadcastChannel(eventType, ufcNumber = null) {
-    switch(eventType) {
-      case 'ppv':
-        // Pay-Per-View events in UK
-        return 'TNT Sports Box Office';
-      
-      case 'abc_card':
-        // ABC/ESPN cards shown on TNT Sports in UK
-        return 'TNT Sports 1';
-      
-      case 'fight_night':
-        // Fight Night events on TNT Sports
-        return 'TNT Sports 2';
-      
-      case 'international':
-        // International events may vary
-        return 'TNT Sports 1';
-      
-      default:
-        return 'TNT Sports 1';
-    }
-  }
-  
-  /**
-   * Format UK broadcast information with accurate channels and timing
-   * @param {object} event - UFC event object
-   * @returns {object} Formatted broadcast info
-   */
-  formatUKBroadcastInfo(event) {
-    const channel = this.getUKUFCBroadcastChannel(event.eventType, event.ufcNumber);
-    
-    const broadcastInfo = {
-      channel,
-      earlyPrelimsUK: {
-        time: new Date(event.earlyPrelimsUkTime).toLocaleTimeString('en-GB', { 
-          hour: '2-digit', 
-          minute: '2-digit',
-          hour12: false 
-        }),
-        day: new Date(event.earlyPrelimsUkTime).toLocaleDateString('en-GB', { weekday: 'short' }),
-        channel: event.eventType === 'ppv' ? 'TNT Sports Box Office' : 'TNT Sports 1'
-      },
-      prelimsUK: {
-        time: new Date(event.prelimsUkTime).toLocaleTimeString('en-GB', { 
-          hour: '2-digit', 
-          minute: '2-digit',
-          hour12: false 
-        }),
-        day: new Date(event.prelimsUkTime).toLocaleDateString('en-GB', { weekday: 'short' }),
-        channel: event.eventType === 'ppv' ? 'TNT Sports Box Office' : 'TNT Sports 1'
-      },
-      mainCardUK: {
-        time: new Date(event.mainCardUkTime).toLocaleTimeString('en-GB', { 
-          hour: '2-digit', 
-          minute: '2-digit',
-          hour12: false 
-        }),
-        day: new Date(event.mainCardUkTime).toLocaleDateString('en-GB', { weekday: 'short' }),
-        channel
-      }
-    };
-    
-    return broadcastInfo;
-  }
-
-  /**
-   * Enhance UFC event with accurate times from Google search
-   * @param {object} event - UFC event object
-   * @returns {Promise<object>} Enhanced event with Google data
-   */
-  async enhanceEventWithGoogleData(event) {
-    try {
-      console.log(`🔍 Searching Google for accurate times: ${event.title}`);
-      
-      // Search Google for this specific event
-      const googleData = await this.googleScraper.searchUFCEvent(event.title);
-      
-      if (googleData && googleData.hasValidTimes) {
-        console.log(`✅ Found Google data for: ${event.title}`);
-        
-        // Update event with Google data
-        const enhancedEvent = { ...event };
-        
-        // Update start times if found
-        if (googleData.startTimes.mainCard) {
-          const mainCardTime = googleData.startTimes.mainCard;
-          enhancedEvent.mainCardTime = `${mainCardTime.formatted}:00`;
-          enhancedEvent.time = `${mainCardTime.formatted}:00`;
-          
-          // Calculate UK datetime from the time
-          enhancedEvent.mainCardUkTime = this.calculateUKDateTime(event.date, mainCardTime.hours, mainCardTime.minutes);
-          enhancedEvent.ukDateTime = enhancedEvent.mainCardUkTime;
-        }
-        
-        if (googleData.startTimes.prelims) {
-          const prelimsTime = googleData.startTimes.prelims;
-          enhancedEvent.prelimsTime = `${prelimsTime.formatted}:00`;
-          enhancedEvent.prelimsUkTime = this.calculateUKDateTime(event.date, prelimsTime.hours, prelimsTime.minutes);
-        }
-        
-        if (googleData.startTimes.earlyPrelims) {
-          const earlyTime = googleData.startTimes.earlyPrelims;
-          enhancedEvent.earlyPrelimsTime = `${earlyTime.formatted}:00`;
-          enhancedEvent.earlyPrelimsUkTime = this.calculateUKDateTime(event.date, earlyTime.hours, earlyTime.minutes);
-        }
-        
-        // Update venue if found
-        if (googleData.venue) {
-          enhancedEvent.venue = googleData.venue;
-          enhancedEvent.location = googleData.venue;
-        }
-        
-        // Update broadcast info if found
-        if (googleData.broadcastInfo) {
-          enhancedEvent.broadcast = this.mapGoogleBroadcastToUK(googleData.broadcastInfo);
-        }
-        
-        // Update fight card if found
-        if (googleData.fightCard && googleData.fightCard.length > 0) {
-          enhancedEvent.mainCard = googleData.fightCard.slice(0, 5).map((fight, index) => ({
-            fighter1: fight.fighter1,
-            fighter2: fight.fighter2,
-            weightClass: fight.weightClass,
-            title: index === 0 ? 'Main Event' : ''
-          }));
-        }
-        
-        // Mark as Google-enhanced
-        enhancedEvent.apiSource = 'google_enhanced';
-        enhancedEvent.googleData = true;
-        
-        console.log(`📊 Enhanced event with Google data:`);
-        console.log(`   Main Card: ${enhancedEvent.mainCardTime} (${enhancedEvent.mainCardUkTime})`);
-        console.log(`   Venue: ${enhancedEvent.venue}`);
-        console.log(`   Broadcast: ${enhancedEvent.broadcast}`);
-        
-        return enhancedEvent;
-      } else {
-        console.log(`⚠️ No Google data found for: ${event.title}`);
-        return event;
-      }
-      
-    } catch (error) {
-      console.error(`❌ Error enhancing event with Google: ${error.message}`);
-      return event;
-    }
-  }
-  
-  /**
-   * Calculate UK datetime from date and time components
-   * @param {string} date - Date in YYYY-MM-DD format
-   * @param {number} hours - Hour (0-23)
-   * @param {number} minutes - Minutes
-   * @returns {string} ISO datetime string
-   */
-  calculateUKDateTime(date, hours, minutes) {
-    try {
-      const dateObj = new Date(date);
-      dateObj.setHours(hours, minutes, 0, 0);
-      return dateObj.toISOString();
-    } catch (error) {
-      console.error(`Error calculating UK datetime: ${error.message}`);
-      return new Date().toISOString();
-    }
-  }
-  
-  /**
-   * Map Google broadcast info to UK channels
-   * @param {string} googleBroadcast - Broadcast info from Google
-   * @returns {string} UK channel
-   */
-  mapGoogleBroadcastToUK(googleBroadcast) {
-    const broadcast = googleBroadcast.toLowerCase();
-    
-    if (broadcast.includes('ppv') || broadcast.includes('pay-per-view') || broadcast.includes('box office')) {
-      return 'TNT Sports Box Office';
-    } else if (broadcast.includes('abc') || broadcast.includes('espn')) {
-      return 'TNT Sports 1';
-    } else if (broadcast.includes('tnt sports')) {
-      return googleBroadcast; // Already correct
-    } else {
-      return 'TNT Sports 2'; // Default for Fight Nights
-    }
-  }
-
-  async fetchUpcomingUFCEvents() {
-    try {
-      console.log('🥊 Fetching upcoming UFC events...');
-      
-      // Try API first, but use accurate fallback for reliability
-      const apiEvents = await this.tryApiRequest();
-      
-      if (apiEvents && apiEvents.length > 0) {
-        console.log(`📊 Found ${apiEvents.length} UFC events from API`);
-        console.log('🔍 Trying to enhance events with Google search data...');
-      
-      // Enhance events with Google data
-      const enhancedEvents = [];
-      for (const event of apiEvents) {
-        const enhancedEvent = await this.enhanceEventWithGoogleData(event);
-        enhancedEvents.push(enhancedEvent);
-      }
-      
-      return enhancedEvents;
-      } else {
-        console.log('⚠️ API returned no current events - using accurate current event data enhanced with Google');
-        return this.getGoogleEnhancedEvents();
-      }
-      
-    } catch (error) {
-      console.error('❌ Error fetching UFC events:', error.message);
-      console.log('🎯 Using accurate current UFC event data enhanced with Google');
-      return this.getGoogleEnhancedEvents();
-    }
-  }
-
-  async tryApiRequest() {
-    try {
-      const events = await this.makeApiRequest(`/searchevents.php?e=UFC`);
-      
-      if (!events || !events.event) {
-        return null;
-      }
-
-      // Filter for upcoming events in 2025
-      const now = new Date();
-      const upcomingEvents = events.event.filter(event => {
-        const eventDate = new Date(event.dateEvent);
-        return eventDate >= now && event.dateEvent >= '2025-01-01' && event.dateEvent <= '2025-12-31';
-      });
-      
-      if (upcomingEvents.length === 0) {
-        return null;
-      }
-      
-      return this.processUFCEvents(upcomingEvents);
-      
-    } catch (error) {
-      console.log('API request failed, using fallback data');
-      return null;
-    }
-  }
-
-  /**
-   * Get current UFC events enhanced with Google search data
-   * @returns {Promise<array>} Enhanced UFC events
-   */
-  async getGoogleEnhancedEvents() {
-    console.log('🚀 Getting UFC events with Google enhancement...');
-    
-    try {
-      const baseEvents = this.getCurrentUFCEvents();
-      const enhancedEvents = [];
-      
-      for (const event of baseEvents) {
-        console.log(`🔍 Enhancing event: ${event.title}`);
-        const enhancedEvent = await this.enhanceEventWithGoogleData(event);
-        enhancedEvents.push(enhancedEvent);
-      }
-      
-      console.log(`✅ Enhanced ${enhancedEvents.length} events with Google data`);
-      return enhancedEvents;
-      
-    } catch (error) {
-      console.error(`❌ Error getting Google enhanced events: ${error.message}`);
-      console.log('⚠️ Falling back to base events');
-      return this.getCurrentUFCEvents();
-    }
-  }
-
-  getCurrentUFCEvents() {
-    // Accurate current UFC events with precise timing based on event type and broadcast requirements
-    return [
-      {
-        id: 'ufc_on_abc_6_hill_vs_rountree_2025',
-        title: 'UFC on ABC 6: Hill vs Rountree Jr.',
-        date: '2025-06-21',
-        
-        // ABC/ESPN events typically start earlier for prime time
-        time: '20:00:00', // 8 PM ET main card start
-        ukDateTime: '2025-06-22T01:00:00.000Z', // 1 AM UK time Sunday (CORRECTED)
-        
-        // Card timing breakdown - CORRECTED UK TIMES
-        earlyPrelimsTime: '18:00:00', // 6 PM ET
-        earlyPrelimsUkTime: '2025-06-21T23:00:00.000Z', // 11 PM UK Saturday
-        
-        prelimsTime: '19:00:00', // 7 PM ET  
-        prelimsUkTime: '2025-06-22T00:00:00.000Z', // Midnight UK Sunday (CORRECTED)
-        
-        mainCardTime: '20:00:00', // 8 PM ET
-        mainCardUkTime: '2025-06-22T01:00:00.000Z', // 1 AM UK Sunday (CORRECTED)
-        
-        location: 'UFC APEX, Las Vegas, Nevada, United States',
-        venue: 'UFC APEX',
-        eventType: 'abc_card', // ABC/ESPN events
-        timezone: 'America/New_York', // Eastern Time
-        status: 'upcoming',
-        description: 'UFC on ABC 6 featuring Jamahal Hill vs Khalil Rountree Jr. in the main event',
-        poster: null,
-        createdAt: new Date().toISOString(),
-        apiSource: 'manual_accurate_data',
-        apiEventId: 'ufc_abc_6_2025',
-        
-        // Enhanced timing information for ABC card
-        broadcastTimes: {
-          earlyPrelims: {
-            et: '18:00', uk: '23:00', local: '15:00 PDT'
-          },
-          prelims: {
-            et: '19:00', uk: '00:00+1', local: '16:00 PDT'
-          },
-          mainCard: {
-            et: '20:00', uk: '01:00+1', local: '17:00 PDT'
-          }
-        },
-        
-        mainCard: [
-          { 
-            fighter1: 'Jamahal Hill', 
-            fighter2: 'Khalil Rountree Jr.', 
-            weightClass: 'Light Heavyweight', 
-            title: 'Main Event' 
-          },
-          { 
-            fighter1: 'Chris Weidman', 
-            fighter2: 'Eryk Anders', 
-            weightClass: 'Middleweight', 
-            title: '' 
-          },
-          { 
-            fighter1: 'Diego Lopes', 
-            fighter2: 'Brian Ortega', 
-            weightClass: 'Featherweight', 
-            title: '' 
-          },
-          { 
-            fighter1: 'Punahele Soriano', 
-            fighter2: 'Uros Medic', 
-            weightClass: 'Welterweight', 
-            title: '' 
-          },
-          { 
-            fighter1: 'Payton Talbott', 
-            fighter2: 'Yanis Ghemmouri', 
-            weightClass: 'Bantamweight', 
-            title: '' 
-          }
-        ],
-        
-        prelimCard: [
-          { 
-            fighter1: 'Roman Kopylov', 
-            fighter2: 'Chris Curtis', 
-            weightClass: 'Middleweight' 
-          },
-          { 
-            fighter1: 'Tabatha Ricci', 
-            fighter2: 'Tecia Pennington', 
-            weightClass: "Women's Strawweight" 
-          },
-          { 
-            fighter1: 'Azamat Murzakanov', 
-            fighter2: 'Alonzo Menifield', 
-            weightClass: 'Light Heavyweight' 
-          },
-          { 
-            fighter1: 'Chris Padilla', 
-            fighter2: 'Joanderson Brito', 
-            weightClass: 'Featherweight' 
-          }
-        ],
-        
-        earlyPrelimCard: [
-          { 
-            fighter1: 'Karine Silva', 
-            fighter2: 'Ketlen Souza', 
-            weightClass: "Women's Flyweight" 
-          },
-          { 
-            fighter1: 'Manuel Torres', 
-            fighter2: 'Kollin Pucek', 
-            weightClass: 'Lightweight' 
-          },
-          { 
-            fighter1: 'Journey Newson', 
-            fighter2: 'Sean Woodson', 
-            weightClass: 'Featherweight' 
-          }
-        ],
-        
-        ufcNumber: null, // ABC card, not numbered event
-        broadcast: this.getUKUFCBroadcastChannel('abc_card'),
-        ticketInfo: 'UFC on ABC 6 Hill vs Rountree Jr June 21 2025'
-      },
-      
-      // Add next upcoming event - Fight Night events have different timing than PPV/ABC
-      {
-        id: 'ufc_fight_night_blanchfield_vs_barber_2025',
-        title: 'UFC Fight Night: Blanchfield vs Barber',
-        date: '2025-05-31',
-        
-        // Fight Night events typically start later on Saturday nights
-        time: '22:00:00', // 10 PM ET main card start
-        ukDateTime: '2025-06-01T03:00:00.000Z', // 3 AM UK time Sunday (CORRECTED)
-        
-        // Card timing breakdown for Fight Night - CORRECTED UK TIMES
-        earlyPrelimsTime: '19:00:00', // 7 PM ET
-        earlyPrelimsUkTime: '2025-06-01T00:00:00.000Z', // Midnight UK Sunday (CORRECTED)
-        
-        prelimsTime: '20:00:00', // 8 PM ET (CORRECTED - was 21:00)
-        prelimsUkTime: '2025-06-01T01:00:00.000Z', // 1 AM UK Sunday (CORRECTED)
-        
-        mainCardTime: '22:00:00', // 10 PM ET
-        mainCardUkTime: '2025-06-01T03:00:00.000Z', // 3 AM UK Sunday (CORRECTED)
-        
-        location: 'UFC APEX, Las Vegas, Nevada, United States',
-        venue: 'UFC APEX',
-        eventType: 'fight_night', // ESPN+ Fight Night
-        timezone: 'America/New_York',
-        status: 'upcoming',
-        description: 'UFC Fight Night featuring Erin Blanchfield vs Maycee Barber in the main event',
-        poster: null,
-        createdAt: new Date().toISOString(),
-        apiSource: 'manual_accurate_data',
-        apiEventId: 'ufc_fight_night_may_31_2025',
-        
-        // Fight Night timing information - CORRECTED
-        broadcastTimes: {
-          earlyPrelims: {
-            et: '19:00', uk: '00:00+1', local: '16:00 PDT'
-          },
-          prelims: {
-            et: '20:00', uk: '01:00+1', local: '17:00 PDT'
-          },
-          mainCard: {
-            et: '22:00', uk: '03:00+1', local: '19:00 PDT'
-          }
-        },
-        
-        mainCard: [
-          { 
-            fighter1: 'Erin Blanchfield', 
-            fighter2: 'Maycee Barber', 
-            weightClass: "Women's Flyweight", 
-            title: 'Main Event' 
-          },
-          { 
-            fighter1: 'Mateusz Gamrot', 
-            fighter2: 'Ludovit Klein', 
-            weightClass: 'Lightweight', 
-            title: '' 
-          },
-          { 
-            fighter1: 'Dustin Jacoby', 
-            fighter2: 'Bruno Lopes', 
-            weightClass: 'Light Heavyweight', 
-            title: '' 
-          },
-          { 
-            fighter1: 'Zach Reese', 
-            fighter2: 'Dusko Todorovic', 
-            weightClass: 'Middleweight', 
-            title: '' 
-          }
-        ],
-        
-        prelimCard: [
-          { 
-            fighter1: 'Allan Nascimento', 
-            fighter2: 'Jafel Filho', 
-            weightClass: 'Flyweight' 
-          },
-          { 
-            fighter1: 'Andreas Gustafsson', 
-            fighter2: 'Jeremiah Wells', 
-            weightClass: 'Welterweight' 
-          },
-          { 
-            fighter1: 'Ketlen Vieira', 
-            fighter2: 'Macy Chiasson', 
-            weightClass: "Women's Bantamweight" 
-          },
-          { 
-            fighter1: 'Rayanne dos Santos', 
-            fighter2: 'Alice Ardelean', 
-            weightClass: "Women's Strawweight" 
-          }
-        ],
-        
-        earlyPrelimCard: [], // Fight Night events typically don't have early prelims
-        
-        ufcNumber: null, // Fight Night, not numbered event
-        broadcast: this.getUKUFCBroadcastChannel('fight_night'),
-        ticketInfo: 'UFC Fight Night Blanchfield vs Barber May 31 2025'
-      }
-    ];
-  }
-
-  async fetchRecentUFCEvents() {
-    try {
-      console.log('🥊 Fetching recent UFC events...');
-      
-      // Try API for recent events
-      const events = await this.makeApiRequest(`/searchevents.php?e=UFC`);
-      
-      if (!events || !events.event) {
-        console.log('⚠️ No recent UFC events found from API');
-        return this.getRecentUFCEvents();
-      }
-
-      // Only get events from last 60 days
-      const sixtyDaysAgo = new Date(Date.now() - (60 * 24 * 60 * 60 * 1000));
-      const now = new Date();
-      const recentEvents = events.event.filter(event => {
-        const eventDate = new Date(event.dateEvent);
-        return eventDate >= sixtyDaysAgo && eventDate <= now;
-      });
-
-      console.log(`📊 Found ${recentEvents.length} recent UFC events from API`);
-      
-      if (recentEvents.length === 0) {
-        return this.getRecentUFCEvents();
-      }
-      
-      return this.processUFCEvents(recentEvents);
-      
-    } catch (error) {
-      console.error('❌ Error fetching recent UFC events:', error.message);
-      return this.getRecentUFCEvents();
-    }
-  }
-
-  getRecentUFCEvents() {
-    // Recent UFC events with accurate data
-    return [
-      {
-        id: 'ufc_302_makhachev_vs_poirier_2024',
-        title: 'UFC 302: Makhachev vs Poirier',
-        date: '2024-06-01',
-        time: '22:00:00',
-        ukDateTime: '2024-06-02T03:00:00.000Z',
-        location: 'Prudential Center, Newark, New Jersey, United States',
-        venue: 'Prudential Center',
-        status: 'finished',
-        description: 'UFC 302 featuring Islam Makhachev vs Dustin Poirier for the Lightweight Championship',
-        poster: null,
-        createdAt: new Date().toISOString(),
-        apiSource: 'manual_accurate_data',
-        apiEventId: 'ufc_302_2024',
-        
-        mainCard: [
-          { 
-            fighter1: 'Islam Makhachev', 
-            fighter2: 'Dustin Poirier', 
-            weightClass: 'Lightweight', 
-            title: 'Lightweight Championship' 
-          },
-          { 
-            fighter1: 'Sean Strickland', 
-            fighter2: 'Paulo Costa', 
-            weightClass: 'Middleweight', 
-            title: '' 
-          },
-          { 
-            fighter1: 'Kevin Holland', 
-            fighter2: 'Michal Oleksiejczuk', 
-            weightClass: 'Middleweight', 
-            title: '' 
-          }
-        ],
-        
-        prelimCard: [],
-        earlyPrelimCard: [],
-        
-        ufcNumber: '302',
-        broadcast: 'TNT Sports Box Office',
-        ticketInfo: 'UFC 302 Newark June 1 2024'
-      }
-    ];
-  }
-
-  makeApiRequest(endpoint) {
-    return new Promise((resolve, reject) => {
-      const options = {
-        hostname: this.baseUrl,
-        path: this.apiPath + endpoint,
-        method: 'GET',
-        headers: {
-          'User-Agent': 'SportsApp/1.0'
-        }
-      };
-
-      const req = https.request(options, (res) => {
-        let data = '';
-        
-        res.on('data', (chunk) => {
-          data += chunk;
-        });
-        
-        res.on('end', () => {
-          try {
-            const jsonData = JSON.parse(data);
-            if (res.statusCode === 200) {
-              resolve(jsonData);
-            } else {
-              reject(new Error(`API Error: ${res.statusCode} - ${data}`));
-            }
-          } catch (e) {
-            reject(new Error(`JSON Parse Error: ${e.message}`));
-          }
-        });
-      });
-
-      req.on('error', (error) => {
-        reject(new Error(`Request Error: ${error.message}`));
-      });
-
-      req.setTimeout(15000, () => {
-        req.destroy();
-        reject(new Error('Request timeout'));
-      });
-
-      req.end();
+  constructor(debugLogCallback = null) {
+    this.debugLog = debugLogCallback || ((category, message, data) => {
+      // console.log(`[${category.toUpperCase()}] ${message}`, data || '');
     });
+
+    // this.googleScraper = new GoogleUFCScraper(); // Removed
+    this.dataManager = null; // Assuming this might be set externally if needed for saving
+    this.isLocal = this.detectLocalEnvironment();
+    this.netlifyFunctionUrl = '/.netlify/functions/fetch-ufc';
+
+    this.ufcEventsCache = [];
+    this.lastUFCEventsFetchTime = null;
   }
 
-  processUFCEvents(apiEvents) {
-    const processedEvents = [];
+  detectLocalEnvironment() {
+    // Simplified check for local Node.js execution vs. potential browser context
+    return typeof window === 'undefined';
+  }
 
-    apiEvents.forEach(event => {
+  /**
+   * Main method to get upcoming UFC events using Google Custom Search API.
+   */
+  async fetchUpcomingUFCEvents() {
+    this.debugLog('api-ufc', 'Fetching upcoming UFC events via Google Custom Search API...');
+
+    const apiKey = process.env.GOOGLE_API_KEY;
+    const searchEngineId = process.env.SEARCH_ENGINE_ID;
+
+    if (!apiKey || !searchEngineId) {
+      this.debugLog('api-ufc', 'ERROR: Missing GOOGLE_API_KEY or SEARCH_ENGINE_ID environment variables.');
+      console.error('ERROR: Missing GOOGLE_API_KEY or SEARCH_ENGINE_ID environment variables.');
+      return []; // Or throw an error
+    }
+
+    const query = "upcoming UFC events UK time";
+    const numResults = 5; // Fetch a few results
+    const apiUrl = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${searchEngineId}&q=${encodeURIComponent(query)}&num=${numResults}`;
+
+    try {
+      this.debugLog('api-ufc', `Requesting Google Custom Search API: ${apiUrl.replace(apiKey, "REDACTED_API_KEY")}`);
+
+      const apiResponsePromise = new Promise((resolve, reject) => {
+        const req = https.get(apiUrl, { headers: { 'Accept': 'application/json' } }, (res) => {
+          let rawData = '';
+          res.on('data', (chunk) => rawData += chunk);
+          res.on('end', () => {
+            this.debugLog('api-ufc', `API Response Status: ${res.statusCode}`);
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+              resolve(rawData);
+            } else {
+              this.debugLog('api-ufc', `API request failed. Status: ${res.statusCode}. Response: ${rawData.substring(0,500)}`);
+              reject(new Error(`API request failed with status ${res.statusCode}.`));
+            }
+          });
+        });
+        req.on('error', (e) => {
+          this.debugLog('api-ufc', 'API request error:', e.message);
+          reject(new Error(`API request error: ${e.message}`));
+        });
+        req.end();
+      });
+
+      const rawApiResponse = await apiResponsePromise;
+      const apiResponseJson = JSON.parse(rawApiResponse);
+
+      this.debugLog('api-ufc', 'Raw API Response Summary:', {
+        itemCount: apiResponseJson.items ? apiResponseJson.items.length : 0,
+        firstItemTitle: apiResponseJson.items && apiResponseJson.items.length > 0 ? apiResponseJson.items[0].title : null
+      });
+
+      const events = this.parseEventsFromGoogleAPI_Local(apiResponseJson);
+      this.ufcEventsCache = events;
+      this.lastUFCEventsFetchTime = new Date().getTime();
+      return events;
+
+    } catch (error) {
+      this.debugLog('api-ufc', `Error fetching or parsing UFC events from Google API: ${error.message}`);
+      console.error(`[UFCFetcher] Error: ${error.message}`, error.stack);
+      return []; // Return empty array on error
+    }
+  }
+
+  /**
+   * Parses events from Google Custom Search API JSON response (local version).
+   * @param {object} apiResponseJson - The parsed JSON object from the API.
+   * @returns {Array<object>} An array of parsed UFC event objects.
+   */
+  parseEventsFromGoogleAPI_Local(apiResponseJson) {
+    const events = [];
+    this.debugLog('parser-ufc', 'Parsing Google API response for UFC events...');
+
+    if (!apiResponseJson.items || apiResponseJson.items.length === 0) {
+      this.debugLog('parser-ufc', 'No items found in API response.');
+      return events;
+    }
+
+    apiResponseJson.items.forEach((item, index) => {
       try {
-        if (!event.strEvent || !event.dateEvent) {
-          console.warn(`⚠️ Missing critical info for UFC event ${event.idEvent || '(no ID)'}`);
+        this.debugLog('parser-ufc', `Processing item ${index + 1}: "${item.title}"`);
+        let eventTitle = item.title;
+        let eventStartDateISO = null;
+        let venue = "Venue TBD";
+        let mainCardTimeStr = "TBD";
+        let prelimTimeStr = "TBD"; // Default
+
+        if (item.pagemap) {
+          if (item.pagemap.metatags && item.pagemap.metatags[0] && item.pagemap.metatags[0]['og:title']) {
+            eventTitle = item.pagemap.metatags[0]['og:title'];
+          }
+          
+          const sportEvent = item.pagemap.sportsEvent || item.pagemap.event;
+          if (sportEvent && sportEvent[0]) {
+            eventStartDateISO = sportEvent[0].startDate || sportEvent[0].startdate;
+            if(eventStartDateISO) this.debugLog('parser-ufc', `Found structured start date: ${eventStartDateISO}`);
+
+            if (sportEvent[0].location) {
+              venue = typeof sportEvent[0].location === 'string'
+                ? sportEvent[0].location
+                : (sportEvent[0].location.name || "Venue TBD");
+              if(venue !== "Venue TBD") this.debugLog('parser-ufc', `Found structured venue: ${venue}`);
+            }
+          }
+        }
+
+        eventTitle = eventTitle.replace(/\s-\sUFC$/i, '').replace(/UFC\s*:\s*/i, '').replace(/\s*\|\s*[^|]+$/,'').trim();
+
+        if (!eventStartDateISO) {
+          this.debugLog('parser-ufc', `No structured start date for "${eventTitle}". Skipping.`);
           return;
         }
 
-        const eventDateAsUtc = new Date(event.dateEvent + 'T' + (event.strTime || '00:00:00') + 'Z');
-        let londonDateTimeIsoString = null;
-
-        if (!isNaN(eventDateAsUtc.getTime())) {
-          const options = {
-            timeZone: "Europe/London",
-            year: 'numeric', month: '2-digit', day: '2-digit',
-            hour: '2-digit', minute: '2-digit', second: '2-digit',
-            hour12: false
-          };
-          
-          const formatter = new Intl.DateTimeFormat('sv-SE', options); 
-          const parts = formatter.formatToParts(eventDateAsUtc);
-          
-          const dateParts = {};
-          for (const part of parts) {
-            if (part.type !== 'literal') {
-              dateParts[part.type] = part.value;
-            }
-          }
-          
-          if (dateParts.hour === '24') {
-            dateParts.hour = '00';
-          }
-
-          if (dateParts.year && dateParts.month && dateParts.day && dateParts.hour && dateParts.minute && dateParts.second) {
-            londonDateTimeIsoString = `${dateParts.year}-${dateParts.month}-${dateParts.day}T${dateParts.hour}:${dateParts.minute}:${dateParts.second}.000Z`;
-          }
+        const mainCardUTCDate = new Date(eventStartDateISO);
+        if (isNaN(mainCardUTCDate.getTime())) {
+          this.debugLog('parser-ufc', `Invalid date from structured data for "${eventTitle}": ${eventStartDateISO}`);
+          return;
         }
         
-        const processedEvent = {
-          id: `ufc_${event.idEvent || 'unknown_' + (Date.now() + Math.random()).toString(36)}`,
-          title: event.strEvent,
-          date: event.dateEvent,
-          time: event.strTime || 'TBD',
-          ukDateTime: londonDateTimeIsoString,
-          location: this.buildLocation(event),
-          venue: event.strVenue || 'TBD',
-          status: this.mapStatus(event.strStatus),
-          description: event.strDescriptionEN || '',
-          poster: event.strPoster || event.strThumb || null,
+        const displayTimeOpts = { hour: '2-digit', minute: '2-digit', timeZone: 'Europe/London', weekday: 'short', hour12: false };
+        mainCardTimeStr = mainCardUTCDate.toLocaleTimeString('en-GB', displayTimeOpts);
+
+        const prelimUTCDate = new Date(mainCardUTCDate.getTime() - (2 * 60 * 60 * 1000)); // Assume 2 hours before
+        prelimTimeStr = prelimUTCDate.toLocaleTimeString('en-GB', displayTimeOpts);
+
+        const parsedDate = mainCardUTCDate.toISOString().split('T')[0];
+        // Time here is the main card UTC hour and minute for consistency with previous structure, though less critical now
+        const originalTime = `${String(mainCardUTCDate.getUTCHours()).padStart(2,'0')}:${String(mainCardUTCDate.getUTCMinutes()).padStart(2,'0')}`;
+
+        const eventObject = {
+          id: `gcse_${item.cacheId || new Date().getTime() + index}`,
+          title: eventTitle,
+          date: parsedDate,
+          time: originalTime,
+          ukDateTime: mainCardUTCDate.toISOString(),
+          ukMainCardTime: mainCardTimeStr,
+          ukPrelimTime: prelimTimeStr,
+          location: venue,
+          venue: venue,
+          status: 'upcoming',
+          description: item.snippet || `Upcoming UFC event: ${eventTitle}`,
+          poster: item.pagemap?.cse_image?.[0]?.src || item.pagemap?.cse_thumbnail?.[0]?.src || null,
           createdAt: new Date().toISOString(),
-          apiSource: 'thesportsdb.com',
-          apiEventId: event.idEvent,
-          
-          // Enhanced parsing that tries to extract real fighter names
-          mainCard: this.parseMainCardFromAPI(event),
-          prelimCard: this.parsePrelimCardFromAPI(event),
-          earlyPrelimCard: this.parseEarlyPrelimCardFromAPI(event),
-          
-          ufcNumber: this.extractUFCNumber(event.strEvent),
-          broadcast: this.determineBroadcast(event),
-          ticketInfo: event.strFilename || null
+          apiSource: 'google_custom_search_api',
+          mainCard: [],
+          prelimCard: [],
+          earlyPrelimCard: [],
+          ufcNumber: eventTitle.match(/UFC\s*(\d+)/i)?.[1] || null,
+          broadcast: "TNT Sports",
+          ticketInfo: `Tickets for ${eventTitle}`
         };
+        events.push(eventObject);
+        this.debugLog('parser-ufc', `Successfully parsed event: "${eventTitle}" for ${parsedDate} at ${mainCardTimeStr} (UK)`);
 
-        processedEvents.push(processedEvent);
-        
-      } catch (error) {
-        console.error(`Error processing UFC event ${event.idEvent || '(no ID)'}:`, error.message);
+      } catch (e) {
+        this.debugLog('parser-ufc', `Error processing item ${index} ("${item.title}"): ${e.message}`, e.stack);
       }
     });
-
-    return processedEvents.sort((a, b) => {
-      if (a.ukDateTime === null && b.ukDateTime === null) return 0;
-      if (a.ukDateTime === null) return 1; 
-      if (b.ukDateTime === null) return -1;
-      return new Date(a.ukDateTime) - new Date(b.ukDateTime);
-    });
+    
+    events.sort((a, b) => new Date(a.ukDateTime) - new Date(b.ukDateTime));
+    this.debugLog('parser-ufc', `Finished parsing. Found ${events.length} valid events.`);
+    return events;
   }
 
-  parseMainCardFromAPI(event) {
-    const description = event.strDescriptionEN || '';
-    const eventTitle = event.strEvent || '';
-    
-    // Try to extract main event from title
-    const titleMatch = eventTitle.match(/UFC[^:]*:\s*(.+?)\s+v[s]?\s+(.+)/i);
-    if (titleMatch) {
-      const mainEvent = {
-        fighter1: titleMatch[1].trim(),
-        fighter2: titleMatch[2].trim(),
-        weightClass: this.determineWeightClassFromNames(titleMatch[1], titleMatch[2]),
-        title: 'Main Event'
-      };
-      
-      // Add realistic co-main and supporting fights
-      return [
-        mainEvent,
-        { 
-          fighter1: 'Co-Main Fighter A', 
-          fighter2: 'Co-Main Fighter B', 
-          weightClass: this.getRandomWeightClass(), 
-          title: '' 
-        },
-        { 
-          fighter1: 'Featured Fighter A', 
-          fighter2: 'Featured Fighter B', 
-          weightClass: this.getRandomWeightClass(), 
-          title: '' 
-        }
-      ];
-    }
-    
-    // If no title match, try parsing description
-    if (description.includes(' vs ') || description.includes(' v ')) {
-      const lines = description.split('\n').filter(line => 
-        (line.includes(' vs ') || line.includes(' v ')) && line.trim().length > 5
-      );
-      
-      if (lines.length > 0) {
-        return lines.slice(0, 4).map((line, index) => {
-          const fighters = line.split(/ vs | v /i);
-          if (fighters.length >= 2) {
-            return {
-              fighter1: fighters[0].trim(),
-              fighter2: fighters[1].trim(),
-              weightClass: this.extractWeightClass(line),
-              title: index === 0 ? 'Main Event' : ''
-            };
-          }
-          return null;
-        }).filter(Boolean);
-      }
-    }
-    
-    // Fallback to current accurate data
-    return this.getCurrentUFCEvents()[0].mainCard;
-  }
-
-  parsePrelimCardFromAPI(event) {
-    const description = event.strDescriptionEN || '';
-    
-    // Try to extract more fights from description
-    if (description.includes(' vs ') || description.includes(' v ')) {
-      const lines = description.split('\n').filter(line => 
-        (line.includes(' vs ') || line.includes(' v ')) && line.trim().length > 5
-      );
-      
-      if (lines.length > 3) {
-        return lines.slice(3, 7).map(line => {
-          const fighters = line.split(/ vs | v /i);
-          if (fighters.length >= 2) {
-            return {
-              fighter1: fighters[0].trim(),
-              fighter2: fighters[1].trim(),
-              weightClass: this.extractWeightClass(line)
-            };
-          }
-          return null;
-        }).filter(Boolean);
-      }
-    }
-    
-    // Return current accurate prelim data as fallback
-    return this.getCurrentUFCEvents()[0].prelimCard;
-  }
-  
-  parseEarlyPrelimCardFromAPI(event) {
-    // Most API events don't have detailed early prelim info
-    return this.getCurrentUFCEvents()[0].earlyPrelimCard;
-  }
-
-  determineWeightClassFromNames(fighter1, fighter2) {
-    // Basic weight class determination based on known fighters
-    const lightweights = ['islam makhachev', 'dustin poirier', 'charles oliveira', 'justin gaethje'];
-    const lightHeavyweights = ['jamahal hill', 'khalil rountree', 'alex pereira', 'jan blachowicz'];
-    const middleweights = ['israel adesanya', 'sean strickland', 'dricus du plessis'];
-    const welterweights = ['leon edwards', 'kamaru usman', 'colby covington'];
-    
-    const f1Lower = fighter1.toLowerCase();
-    const f2Lower = fighter2.toLowerCase();
-    
-    if (lightweights.some(name => f1Lower.includes(name) || f2Lower.includes(name))) {
-      return 'Lightweight';
-    }
-    if (lightHeavyweights.some(name => f1Lower.includes(name) || f2Lower.includes(name))) {
-      return 'Light Heavyweight';
-    }
-    if (middleweights.some(name => f1Lower.includes(name) || f2Lower.includes(name))) {
-      return 'Middleweight';
-    }
-    if (welterweights.some(name => f1Lower.includes(name) || f2Lower.includes(name))) {
-      return 'Welterweight';
-    }
-    
-    return 'TBD';
-  }
-
-  buildLocation(event) {
-    const parts = [];
-    if (event.strVenue) parts.push(event.strVenue);
-    if (event.strCity) parts.push(event.strCity);
-    if (event.strCountry) parts.push(event.strCountry);
-    return parts.join(', ') || 'TBD';
-  }
-
-  mapStatus(apiStatus) {
-    return this.statusMap[apiStatus] || 'upcoming';
-  }
-
-  extractUFCNumber(eventTitle) {
-    if (!eventTitle) return null;
-    const match = eventTitle.match(/UFC\s+(\d+)/i);
-    return match ? match[1] : null;
-  }
-
-  determineBroadcast(event) {
-    const title = (event.strEvent || '').toLowerCase();
-    
-    // Determine event type first
-    let eventType = 'fight_night'; // default
-    
-    if (title.includes('ppv') || /ufc\s+\d+/.test(title)) {
-      eventType = 'ppv';
-    } else if (title.includes('on abc') || title.includes('on espn')) {
-      eventType = 'abc_card';
-    } else if (title.includes('fight night')) {
-      eventType = 'fight_night';
-    }
-    
-    // Return accurate UK channel
-    return this.getUKUFCBroadcastChannel(eventType);
-  }
-
-  getRandomWeightClass() {
-    const weightClasses = [
-      'Heavyweight', 'Light Heavyweight', 'Middleweight', 'Welterweight',
-      'Lightweight', 'Featherweight', 'Bantamweight', 'Flyweight',
-      'Women\'s Bantamweight', 'Women\'s Flyweight', 'Women\'s Strawweight'
-    ];
-    
-    return weightClasses[Math.floor(Math.random() * weightClasses.length)];
-  }
-
-  extractWeightClass(fightLine) {
-    const weightClasses = [
-      'Heavyweight', 'Light Heavyweight', 'Middleweight', 'Welterweight',
-      'Lightweight', 'Featherweight', 'Bantamweight', 'Flyweight',
-      'Women\'s Bantamweight', 'Women\'s Flyweight', 'Women\'s Strawweight'
-    ];
-    
-    for (const weightClass of weightClasses) {
-      if (fightLine.toLowerCase().includes(weightClass.toLowerCase())) {
-        return weightClass;
-      }
-    }
-    return 'TBD';
-  }
-
+  /**
+   * Updates UFC data, intended to be called by dataManager or similar.
+   * This will now use the new API-based fetch method.
+   */
   async updateUFCData() {
-    try {
-      console.log('🔄 Starting UFC data update...');
-      
-      const DataManager = require('./dataManager');
-      const dataManager = new DataManager();
-      const existingData = dataManager.loadData();
-      
-      // Fetch both upcoming and recent events
-      const [upcomingEvents, recentEvents] = await Promise.all([
-        this.fetchUpcomingUFCEvents(),
-        this.fetchRecentUFCEvents()
-      ]);
-      
-      // Combine and deduplicate events
-      const allEvents = [...recentEvents, ...upcomingEvents];
-      const uniqueEvents = this.deduplicateEvents(allEvents);
-      
-      if (uniqueEvents.length === 0) {
-        console.log('⚠️ No UFC events found');
-        return { success: true, added: 0, total: existingData.ufcEvents?.length || 0 };
-      }
-
-      // Filter out events that already exist (avoid duplicates)
-      const existingIds = new Set(
-        (existingData.ufcEvents || []).map(e => e.apiEventId).filter(Boolean)
-      );
-      const newEvents = uniqueEvents.filter(event => !existingIds.has(event.apiEventId));
-
-      console.log(`📊 Found ${uniqueEvents.length} total UFC events, ${newEvents.length} are new`);
-
-      // Update UFC events in existing data
-      const existingNonApiEvents = (existingData.ufcEvents || []).filter(e => !e.apiEventId);
-      existingData.ufcEvents = [...existingNonApiEvents, ...uniqueEvents];
-      
-      // Update last fetch timestamp
-      existingData.lastUFCFetch = new Date().toISOString();
-      
-      // Save updated data
-      const saved = dataManager.saveData(existingData);
-      
-      if (saved) {
-        console.log(`✅ Successfully updated UFC data: ${newEvents.length} new events`);
-        console.log(`📊 Total UFC events now: ${existingData.ufcEvents.length}`);
-        
-        newEvents.forEach(event => {
-          console.log(`  🥊 ${event.date} - ${event.title} (${event.location})`);
-        });
-      }
-      
-      return { 
-        success: saved, 
-        added: newEvents.length, 
-        total: existingData.ufcEvents.length,
-        events: newEvents
-      };
-      
-    } catch (error) {
-      console.error('❌ Error updating UFC data:', error.message);
-      return { success: false, error: error.message };
+    this.debugLog('api-ufc', 'updateUFCData called. Fetching new events...');
+    const newEvents = await this.fetchUpcomingUFCEvents();
+    
+    if (newEvents && newEvents.length > 0) {
+      // Here, you would typically merge with existing data if this class managed persistence.
+      // For now, it just updates the cache.
+      this.debugLog('api-ufc', `Fetched ${newEvents.length} new UFC events.`);
+      return { success: true, added: newEvents.length, events: newEvents };
+    } else if (newEvents) { // newEvents is an empty array
+      this.debugLog('api-ufc', 'No new UFC events found.');
+      return { success: true, added: 0, events: [] };
+    } else { // fetch failed, newEvents is undefined or null
+      this.debugLog('api-ufc', 'Failed to fetch UFC events.');
+      return { success: false, added: 0, error: "Failed to fetch UFC events" };
     }
   }
 
-  deduplicateEvents(events) {
-    const seen = new Set();
-    return events.filter(event => {
-      const key = `${event.apiEventId || event.id}_${event.date}`;
-      if (seen.has(key)) {
-        return false;
-      }
-      seen.add(key);
-      return true;
-    });
-  }
-
+  // Test connection method (optional, can be simple for API)
   async testConnection() {
     try {
-      console.log('🔍 Testing UFC API and data accuracy...');
-      const result = await this.makeApiRequest('/searchevents.php?e=UFC');
-      
-      if (result && result.event) {
-        console.log('✅ UFC API connection successful!');
-        
-        const currentEvents = result.event.filter(event => 
-          event.dateEvent >= '2025-05-01' && event.dateEvent <= '2025-12-31'
-        );
-        
-        console.log(`📊 Found ${currentEvents.length} UFC events for 2025 from API`);
-        
-        if (currentEvents.length === 0) {
-          console.log('⚠️ API has no current 2025 UFC events');
-          console.log('🎯 Using accurate manual data: UFC on ABC 6 Hill vs Rountree Jr (June 21)');
-        } else {
-          console.log('🚀 Current UFC events available in API:');
-          currentEvents.slice(0, 3).forEach(event => {
-            console.log(`  🥊 ${event.dateEvent} - ${event.strEvent}`);
-          });
-        }
-        
-        // Always provide accurate current event data
-        console.log('✅ Current accurate UFC event: UFC on ABC 6 Hill vs Rountree Jr');
-        return true;
-      } else {
-        console.log('❌ No events returned from UFC API');
-        console.log('🎯 Using accurate manual data as primary source');
-        return false;
-      }
-    } catch (error) {
-      console.error('❌ UFC API connection failed:', error.message);
-      console.log('🎯 Using accurate manual UFC data');
+      const events = await this.fetchUpcomingUFCEvents();
+      return events && events.length >= 0; // True if API call succeeded (even if 0 events)
+    } catch {
       return false;
     }
   }
 }
 
+// --- Deprecated/Old Functions (Commented Out or To Be Removed) ---
+/*
+  async enhanceEventWithGoogleData(event) { ... }
+  async tryApiRequest(date) { ... } // TheSportsDB
+  processUFCEvents(apiResponse, date) { ... } // TheSportsDB
+  getCurrentUFCEvents() { ... } // Hardcoded fallback
+  getGoogleEnhancedEvents() { ... } // Old scraper logic
+  calculateUKDateTime(eventDate, eventTimeET) { ... } // Old time conversion
+*/
+
+
+// Test execution (if run directly via node ufcFetcher.js)
 if (require.main === module) {
-  const fetcher = new UFCFetcher();
-  
-  fetcher.updateUFCData().then(result => {
-    if (result.success) {
-      console.log(`🎉 UFC update completed: ${result.added} new events added`);
-      process.exit(0);
-    } else {
-      console.error('💥 UFC update failed:', result.error);
-      process.exit(1);
+  (async () => {
+    console.log('🥊 Testing UFCFetcher with Google Custom Search API...');
+    
+    // Simple console log for debug messages from the class
+    const logger = (category, message, data) => {
+        console.log(`[${category.toUpperCase()}] ${message}`, data || '');
+    };
+    const fetcher = new UFCFetcher(logger);
+
+    try {
+      const ufcEvents = await fetcher.fetchUpcomingUFCEvents();
+
+      if (ufcEvents && ufcEvents.length > 0) {
+        console.log('\n✅ Successfully fetched UFC Events:');
+        ufcEvents.forEach(event => {
+          console.log(`--------------------------------------------------`);
+          console.log(`  Title: ${event.title} (UFC ${event.ufcNumber || 'N/A'})`);
+          console.log(`  Date: ${event.date}, Original Time (UTC): ${event.time}`);
+          console.log(`  UK DateTime (ISO): ${event.ukDateTime}`);
+          console.log(`  UK Main Card: ${event.ukMainCardTime}`);
+          console.log(`  UK Prelims: ${event.ukPrelimTime}`);
+          console.log(`  Venue: ${event.venue}`);
+          console.log(`  Source: ${event.apiSource}`);
+          console.log(`  Poster: ${event.poster}`);
+        });
+        console.log(`--------------------------------------------------`);
+        console.log(`\nTotal events fetched: ${ufcEvents.length}`);
+      } else if (ufcEvents) {
+        console.log('🟡 No upcoming UFC events found by the API at this time.');
+      } else {
+        console.log('❌ Failed to fetch UFC events. ufcEvents is undefined or null.');
+      }
+    } catch (error) {
+      console.error('❌ Test execution failed:', error);
     }
-  }).catch(error => {
-    console.error('💥 Unexpected error:', error);
-    process.exit(1);
-  });
+  })();
 }
 
 module.exports = UFCFetcher;


### PR DESCRIPTION
- I rewrote `netlify/functions/fetch-ufc.js` to use the Google Custom Search JSON API as the primary data source, replacing HTML scraping and hardcoded fallbacks.
  - It expects GOOGLE_API_KEY and SEARCH_ENGINE_ID from env vars.
  - It parses the JSON response, prioritizing structured data for event details and UTC times.
  - It converts UTC times to UK display format.
  - It includes a debug mode to return an API JSON response snippet.

- I refactored `ufcFetcher.js` (for local use) to mirror the Netlify function's logic:
  - It uses the Google Custom Search JSON API via environment variables (requires a .env file locally with GOOGLE_API_KEY and SEARCH_ENGINE_ID).
  - It implements similar JSON parsing and time processing for consistency.
  - It deprecates usage of `googleUFCScraper.js` (HTML scraper).

This commit provides the complete set of changes for using the Google Custom Search JSON API for fetching UFC events, for both Netlify and local environments.