### PR TITLE
I've made some changes to help debug the raw items from the Google Cu…

### DIFF
--- a/netlify/functions/fetch-ufc.js
+++ b/netlify/functions/fetch-ufc.js
@@ -251,6 +251,16 @@ exports.handler = async (event, context) => {
         // For now, the responsePayload.debugInfo will hold a snippet of the JSON.
     }
 
+    // Add detailed logging for the raw items array
+    console.log('[Handler] Raw Google API Response Items for query - START:');
+    if (apiResponseJson.items && apiResponseJson.items.length > 0) {
+      const itemsToLog = apiResponseJson.items.slice(0, 5); // Log up to 5 items
+      console.log(JSON.stringify(itemsToLog, null, 2));
+    } else {
+      console.log('[Handler] No items found in Google API Response.');
+    }
+    console.log('[Handler] Raw Google API Response Items for query - END:');
+
     ufcEvents = parseEventsFromGoogleAPI(apiResponseJson);
 
     responsePayload = {


### PR DESCRIPTION
…stom Search API in `fetch-ufc`.

Specifically, I modified `netlify/functions/fetch-ufc.js` to add server-side console logging. This will show the `items` array (up to the first 5 items) that comes from the Google Custom Search JSON API.

This logging will happen after the JSON response is parsed and before any event processing starts.

The goal here is to let you directly look at the data returned by the API through the Netlify Function logs. This should help with figuring out any problems with event parsing or when you're trying to improve your search queries.