### PR TITLE
Fix: Correct case sensitivity for SportsEvent in GCS API parser

### DIFF
--- a/netlify/functions/fetch-ufc.js
+++ b/netlify/functions/fetch-ufc.js
@@ -93,15 +93,16 @@ function parseEventsFromGoogleAPI(apiResponseJson) {
           eventTitle = item.pagemap.metatags[0]['og:title'];
         }
 
-        const sportEvent = item.pagemap.sportsEvent || item.pagemap.event;
+        // Corrected to use item.pagemap.SportsEvent (capital S) first
+        const sportEvent = item.pagemap.SportsEvent || item.pagemap.event;
         if (sportEvent && sportEvent[0]) {
           if (sportEvent[0].startDate || sportEvent[0].startdate) { // Google uses both casings
             eventStartDateISO = sportEvent[0].startDate || sportEvent[0].startdate;
-            console.log(`[API Parse] Found structured start date: ${eventStartDateISO}`);
+            console.log(`[API Parse] Found structured start date from SportsEvent/event: ${eventStartDateISO}`);
           }
           if (sportEvent[0].location) {
             venue = typeof sportEvent[0].location === 'string' ? sportEvent[0].location : (sportEvent[0].location.name || "Venue TBD");
-             console.log(`[API Parse] Found structured venue: ${venue}`);
+             console.log(`[API Parse] Found structured venue from SportsEvent/event: ${venue}`);
           }
         }
       }

--- a/ufcFetcher.js
+++ b/ufcFetcher.js
@@ -114,16 +114,17 @@ class UFCFetcher {
             eventTitle = item.pagemap.metatags[0]['og:title'];
           }
           
-          const sportEvent = item.pagemap.sportsEvent || item.pagemap.event;
+          // Corrected to use item.pagemap.SportsEvent (capital S) first
+          const sportEvent = item.pagemap.SportsEvent || item.pagemap.event;
           if (sportEvent && sportEvent[0]) {
             eventStartDateISO = sportEvent[0].startDate || sportEvent[0].startdate;
-            if(eventStartDateISO) this.debugLog('parser-ufc', `Found structured start date: ${eventStartDateISO}`);
+            if(eventStartDateISO) this.debugLog('parser-ufc', `Found structured start date from SportsEvent/event: ${eventStartDateISO}`);
 
             if (sportEvent[0].location) {
               venue = typeof sportEvent[0].location === 'string'
                 ? sportEvent[0].location
                 : (sportEvent[0].location.name || "Venue TBD");
-              if(venue !== "Venue TBD") this.debugLog('parser-ufc', `Found structured venue: ${venue}`);
+              if(venue !== "Venue TBD") this.debugLog('parser-ufc', `Found structured venue from SportsEvent/event: ${venue}`);
             }
           }
         }


### PR DESCRIPTION
- I modified `parseEventsFromGoogleAPI` in `netlify/functions/fetch-ufc.js` and `parseEventsFromGoogleAPI_Local` in `ufcFetcher.js` to correctly look for `item.pagemap.SportsEvent` (capital 'S') instead of `item.pagemap.sportsEvent`.
- This aligns with the actual field name observed in Google Custom Search JSON API responses containing structured event data.
- This change should enable the parser to correctly access and use the `startDate` and other details provided within the `SportsEvent` object.