### PR TITLE
Fix: Correct invalid Netlify header rule

### DIFF
--- a/_headers
+++ b/_headers
@@ -6,7 +6,7 @@
   Access-Control-Allow-Origin: *
   Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
   Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With
-  Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' https: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; connect-src 'self' https: wss:; frame-ancestors *;
+  Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval' https: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; connect-src 'self' https: wss:
 
 # Netlify Functions headers
 /.netlify/functions/*


### PR DESCRIPTION
Removes `frame-ancestors *` from the Content-Security-Policy in the `_headers` file to resolve Netlify parsing error. This directive was overly permissive and likely causing the validation issue.